### PR TITLE
fix injectAsyncReducer

### DIFF
--- a/app/utils/asyncInjectors.js
+++ b/app/utils/asyncInjectors.js
@@ -33,6 +33,8 @@ export function injectAsyncReducer(store, isValid) {
       '(app/utils...) injectAsyncReducer: Expected `asyncReducer` to be a reducer function'
     );
 
+    if (Reflect.has(store.asyncReducers, name)) return;
+
     store.asyncReducers[name] = asyncReducer; // eslint-disable-line no-param-reassign
     store.replaceReducer(createReducer(store.asyncReducers));
   };


### PR DESCRIPTION
I think there is a bug in the react boilerplate project you forked -> if you add a `console.log(action.type);` in a reducer, for example in **linkListContainerReducer**, you can see the reducer is called multiple times for a single dispatched action. 
After checking the last version of react-boilerplate, I realised they add this line `if (Reflect.has(store.asyncReducers, name)) return;` in the `injectAsyncReducer` function. After restarting the app, the reducer is now called only one time per action.

It would be useful to fix it in your version as it's an initial project from a pluralsight tutorial.  